### PR TITLE
Update warning_lamp_manager following autoware_state_machine removal

### DIFF
--- a/include/warning_lamp_manager/warning_lamp_manager.hpp
+++ b/include/warning_lamp_manager/warning_lamp_manager.hpp
@@ -16,8 +16,17 @@
 #define WARNING_LAMP_MANAGER__WARNING_LAMP_MANAGER_HPP_
 
 #include "rclcpp/rclcpp.hpp"
+#include "autoware_state_machine_msgs/msg/state_lock.hpp"
 #include "autoware_state_machine_msgs/msg/state_machine.hpp"
 #include "dio_ros_driver/msg/dio_port.hpp"
+#include "go_interface_msgs/msg/vehicle_status.hpp"
+#include <autoware_adapi_v1_msgs/msg/localization_initialization_state.hpp>
+#include <autoware_adapi_v1_msgs/msg/route_state.hpp>
+#include <autoware_adapi_v1_msgs/msg/diag_graph_status.hpp>
+#include <autoware_adapi_v1_msgs/msg/diag_graph_struct.hpp>
+#include <autoware_adapi_v1_msgs/msg/operation_mode_state.hpp>
+#include <diagnostic_msgs/msg/diagnostic_status.hpp>
+
 
 namespace warning_lamp_manager
 {
@@ -36,15 +45,67 @@ private:
 
   // Subscriber
   rclcpp::Subscription<autoware_state_machine_msgs::msg::StateMachine>::SharedPtr sub_state_;
+  rclcpp::Subscription<autoware_adapi_v1_msgs::msg::LocalizationInitializationState>::SharedPtr sub_initilization_state_;
+  rclcpp::Subscription<autoware_adapi_v1_msgs::msg::RouteState>::SharedPtr sub_routing_state_;
+  rclcpp::Subscription<autoware_adapi_v1_msgs::msg::DiagGraphStatus>::SharedPtr sub_daignostics_status_;
+  rclcpp::Subscription<autoware_adapi_v1_msgs::msg::DiagGraphStruct>::SharedPtr sub_daignostics_struct_;
+  rclcpp::Subscription<autoware_adapi_v1_msgs::msg::OperationModeState>::SharedPtr sub_operation_mode_state_;
+  rclcpp::Subscription<go_interface_msgs::msg::VehicleStatus>::SharedPtr sub_calls_vehicle_state_;
+  rclcpp::Subscription<autoware_state_machine_msgs::msg::StateLock>::SharedPtr sub_delivery_reservation_state_;
+  rclcpp::Subscription<autoware_state_machine_msgs::msg::StateMachine>::SharedPtr sub_engage_process_state_;
+  
+  std::shared_mutex mtx_;
+  bool is_engage_requesting_;
+  bool is_engage_accepted_;
 
   bool active_polarity_;
   bool use_overridable_vehicle_;
+  uint16_t service_layer_state_;
+  uint16_t control_layer_state_;
+  uint16_t initilization_state_;
+  uint16_t routing_state_;
+  uint16_t delivery_reservation_state_;  
+  std::optional<uint16_t> em_holding_indices_;
+  bool em_holding_;
+  autoware_adapi_v1_msgs::msg::OperationModeState operation_state_;
+  bool flag_calls_vehicle_voice_;
 
   void callbackStateMessage(
     const autoware_state_machine_msgs::msg::StateMachine::ConstSharedPtr msg);
+  void callbackAutowareInitializationMessage(
+    const autoware_adapi_v1_msgs::msg::LocalizationInitializationState::ConstSharedPtr msg);
+  void callbackRoutingStateMessage(
+    const autoware_adapi_v1_msgs::msg::RouteState::ConstSharedPtr msg);
+  void callbackDaignosticsStructMessage(
+    const autoware_adapi_v1_msgs::msg::DiagGraphStruct::ConstSharedPtr msg);
+  void callbackDaignosticsStateMessage(
+    const autoware_adapi_v1_msgs::msg::DiagGraphStatus::ConstSharedPtr msg);
+  void callbackOperationModeStateMessage(
+    const autoware_adapi_v1_msgs::msg::OperationModeState::ConstSharedPtr msg);
+  void callbackVehicleStateMessage(
+    const go_interface_msgs::msg::VehicleStatus::ConstSharedPtr msg);
+  void callbackDeliveryReservationMessage(
+    const autoware_state_machine_msgs::msg::StateLock::ConstSharedPtr msg);
+  void callbackEngageProcessMessage(
+    const autoware_state_machine_msgs::msg::StateMachine::ConstSharedPtr msg);
+
   void controlLampEmergency(const bool value);
   void controlLampWarning(const bool value);
   void warningLampManager(const uint16_t service_layer_state, const uint8_t control_layer_state);
+  void changeState(void);
+  bool isAutowareStateOfWaitingForEngage(void);
+  bool isAutowareStateOfDriving(void);
+  bool isAutowareStateOfWaitingForRoute(void);
+  bool isAutowareStateOfPlanning(void);
+  bool isAutowareStateOfArrivedGoal(void);
+  bool checkStateInformEngage(void);
+  bool checkStateInformRestart(void);
+  bool checkState4DuringReceiveRoute(void);
+  bool checkStateWaitingEngageInstruction(void);
+  bool checkStateWaitingCallPermission(void);
+  bool checkState4Arrived(void);
+  void setEngageProcess(bool request, bool accept);
+  std::pair<bool, bool> getEngageProcess();
 };
 
 }  // namespace warning_lamp_manager

--- a/package.xml
+++ b/package.xml
@@ -30,6 +30,10 @@
   <depend>dio_ros_driver</depend>
   <depend>autoware_state_machine_msgs</depend>
   <depend>rclcpp_components</depend>
+  <depend>autoware_adapi_v1_msgs</depend>
+  <depend>diagnostic_msgs</depend>
+  <depend>go_interface_msgs</depend>
+  <depend>autoware_vehicle_msgs</depend>
 
   <depend>builtin_interfaces</depend>
 

--- a/src/warning_lamp_manager.cpp
+++ b/src/warning_lamp_manager.cpp
@@ -31,6 +31,62 @@ WarningLampManager::WarningLampManager(
     rclcpp::QoS{3}.transient_local(),
     std::bind(&WarningLampManager::callbackStateMessage, this, std::placeholders::_1)
   );
+
+  // autoware_state
+  sub_initilization_state_ = this->create_subscription<autoware_adapi_v1_msgs::msg::LocalizationInitializationState>(
+    "/api/localization/initialization_state",
+    rclcpp::QoS{3}.transient_local(),
+    std::bind(&WarningLampManager::callbackAutowareInitializationMessage, this, std::placeholders::_1)
+  );
+
+  // routing wait state
+  sub_routing_state_ = this->create_subscription<autoware_adapi_v1_msgs::msg::RouteState>(
+    "/api/routing/state",
+    rclcpp::QoS{3}.transient_local(),
+    std::bind(&WarningLampManager::callbackRoutingStateMessage, this, std::placeholders::_1)
+  );
+
+  // daignostics struct for EM Holding
+  sub_daignostics_struct_ = this->create_subscription<autoware_adapi_v1_msgs::msg::DiagGraphStruct>(
+    "/api/system/diagnostics/struct",
+    rclcpp::QoS{3}.transient_local(),
+    std::bind(&WarningLampManager::callbackDaignosticsStructMessage, this, std::placeholders::_1)
+  );
+  sub_daignostics_status_ = this->create_subscription<autoware_adapi_v1_msgs::msg::DiagGraphStatus>(
+    "/api/system/diagnostics/status",
+    rclcpp::QoS{3}.transient_local(),
+    std::bind(&WarningLampManager::callbackDaignosticsStateMessage, this, std::placeholders::_1)
+  );
+
+  // OperationModeState
+  sub_operation_mode_state_ = this->create_subscription<autoware_adapi_v1_msgs::msg::OperationModeState>(
+    "/api/operation_mode/state",
+    rclcpp::QoS{3}.transient_local(),
+    std::bind(&WarningLampManager::callbackOperationModeStateMessage, this, std::placeholders::_1)
+  );
+
+  // vehicle_status
+  sub_calls_vehicle_state_ = this->create_subscription<go_interface_msgs::msg::VehicleStatus>(
+    "api_vehicle_status",
+    rclcpp::QoS{3}.transient_local(),
+    std::bind(&WarningLampManager::callbackVehicleStateMessage, this, std::placeholders::_1)
+  );
+
+  // delivery reservation state
+  sub_delivery_reservation_state_ = this->create_subscription<autoware_state_machine_msgs::msg::StateLock>(
+    "/go_interface/lock_state",
+    rclcpp::QoS{3}.transient_local(),
+    std::bind(&WarningLampManager::callbackDeliveryReservationMessage, this, std::placeholders::_1)
+  );
+
+  // TODO:eve_cmd_gateからengage状態をもらう、topic名とメッセージ型を反映
+  // engage process state
+  sub_engage_process_state_ = this->create_subscription<autoware_state_machine_msgs::msg::StateMachine>(
+    "xxxxx/xxxx",
+    rclcpp::QoS{3}.transient_local(),
+    std::bind(&WarningLampManager::callbackEngageProcessMessage, this, std::placeholders::_1)
+  );
+
   pub_warning_lamp_emergency_ = this->create_publisher<dio_ros_driver::msg::DIOPort>(
     "lamp_emergency_out",
     rclcpp::QoS{3}.transient_local());
@@ -39,6 +95,19 @@ WarningLampManager::WarningLampManager(
     rclcpp::QoS{3}.transient_local());
 
   active_polarity_ = ACTIVE_POLARITY;
+  em_holding_indices_ = std::nullopt;
+  service_layer_state_ = autoware_state_machine_msgs::msg::StateMachine::STATE_UNDEFINED;
+  control_layer_state_ = autoware_state_machine_msgs::msg::StateMachine::MANUAL;
+  initilization_state_ = autoware_adapi_v1_msgs::msg::LocalizationInitializationState::UNKNOWN;
+  routing_state_ = autoware_adapi_v1_msgs::msg::RouteState::UNKNOWN;
+  delivery_reservation_state_ = autoware_state_machine_msgs::msg::StateLock::STATE_OFF;
+  em_holding_ = false;
+  operation_state_.is_autoware_control_enabled = false;
+  operation_state_.is_in_transition = false;
+  operation_state_.is_stop_mode_available = false;
+  operation_state_.is_autonomous_mode_available = false;
+  operation_state_.is_local_mode_available = false;
+  operation_state_.is_remote_mode_available = false;
 
   controlLampWarning(true);
   controlLampEmergency(true);
@@ -62,6 +131,134 @@ void WarningLampManager::callbackStateMessage(
     msg->control_layer_state);
 
   warningLampManager(msg->service_layer_state, msg->control_layer_state);
+}
+
+void WarningLampManager::callbackAutowareInitializationMessage(
+  const autoware_adapi_v1_msgs::msg::LocalizationInitializationState::ConstSharedPtr msg)
+{
+  RCLCPP_INFO_THROTTLE(
+    this->get_logger(),
+    *this->get_clock(), 1.0,
+    "[WarningLampManager::callbackAutowareInitializationMessage]autoware_state: %u",
+    msg->state);
+
+  initilization_state_ = msg->state;
+
+  changeState();
+  warningLampManager(service_layer_state_, control_layer_state_);
+}
+
+void WarningLampManager::callbackRoutingStateMessage(
+  const autoware_adapi_v1_msgs::msg::RouteState::ConstSharedPtr msg)
+{
+  RCLCPP_INFO_THROTTLE(
+    this->get_logger(),
+    *this->get_clock(), 1.0,
+    "[WarningLampManager::callbackRoutingStateMessage]routing_state: %u",
+    msg->state);
+
+  routing_state_ = msg->state;
+
+  changeState();
+  warningLampManager(service_layer_state_, control_layer_state_);
+}
+
+void WarningLampManager::callbackDaignosticsStructMessage(
+  const autoware_adapi_v1_msgs::msg::DiagGraphStruct::ConstSharedPtr msg)
+{
+  auto nodes = msg->nodes;
+
+  for (uint16_t i = 0; i < nodes.size(); ++i) {
+    if (nodes[i].path == "/autoware/modes/autonomous") {
+      em_holding_indices_ = i;
+      RCLCPP_INFO_THROTTLE(
+        this->get_logger(),
+        *this->get_clock(), 1.0,
+        "[WarningLampManager::callbackDaignosticsStructMessage]daignostics_graph /autoware/modes/autonomous index: %u", i);
+      break;
+    }
+  }
+}
+
+void WarningLampManager::callbackDaignosticsStateMessage(
+  const autoware_adapi_v1_msgs::msg::DiagGraphStatus::ConstSharedPtr msg)
+{
+  auto nodes = msg->nodes;
+  if (em_holding_indices_ != std::nullopt) {
+    // TODO:Ph3にて、levelをlatch_levelに変更
+    if (nodes[em_holding_indices_.value()].level == diagnostic_msgs::msg::DiagnosticStatus::ERROR) {
+      em_holding_ = true;
+      RCLCPP_INFO_THROTTLE(
+        this->get_logger(),
+        *this->get_clock(), 1.0,
+        "[WarningLampManager::callbackDaignosticsStateMessage]/autoware/modes/autonomous latch_level: %u",
+        nodes[em_holding_indices_.value()].level);// TODO:Ph3にて、levelをlatch_levelに変更
+    } else {
+      em_holding_ = false;
+    }
+
+    changeState();
+    warningLampManager(service_layer_state_, control_layer_state_);
+  }
+}
+
+void WarningLampManager::callbackOperationModeStateMessage(
+  const autoware_adapi_v1_msgs::msg::OperationModeState::ConstSharedPtr msg)
+{
+  operation_state_ = *msg;
+  RCLCPP_INFO_THROTTLE(
+    this->get_logger(),
+    *this->get_clock(), 1.0,
+    "[WarningLampManager::callbackOperationModeStateMessage]operation mode: %u",
+      msg->mode);
+
+  changeState();
+  warningLampManager(service_layer_state_, control_layer_state_);
+}
+
+void WarningLampManager::callbackVehicleStateMessage(
+  const go_interface_msgs::msg::VehicleStatus::ConstSharedPtr msg)
+{
+  flag_calls_vehicle_voice_ = msg->voice_flg;
+  RCLCPP_INFO_THROTTLE(
+    this->get_logger(),
+    *this->get_clock(), 1.0,
+    "[WarningLampManager::callbackOperationModeStateMessage]vheicle voice: %u",
+      msg->voice_flg);
+
+  changeState();
+  warningLampManager(service_layer_state_, control_layer_state_);
+}
+
+void WarningLampManager::callbackDeliveryReservationMessage(
+  const autoware_state_machine_msgs::msg::StateLock::ConstSharedPtr msg)
+{
+  RCLCPP_INFO_THROTTLE(
+    this->get_logger(),
+    *this->get_clock(), 1.0,
+    "[WarningLampManager::callbackDeliveryReservationMessage]"
+    "StateLock: %u",
+    msg->state);
+
+  delivery_reservation_state_ = msg->state;
+  changeState();
+  warningLampManager(service_layer_state_, control_layer_state_);
+}
+
+void WarningLampManager::callbackEngageProcessMessage(
+  const autoware_state_machine_msgs::msg::StateMachine::ConstSharedPtr msg)
+{
+  RCLCPP_INFO_THROTTLE(
+    this->get_logger(),
+    *this->get_clock(), 1.0,
+    "[WarningLampManager::callbackEngageProcessMessage]"
+    "request: %u, accept: %u",
+    msg->service_layer_state, msg->control_layer_state);
+//    msg->request, msg->accept);
+
+  //setEngageProcess(msg->request, msg->accept);
+  changeState();
+  warningLampManager(service_layer_state_, control_layer_state_);
 }
 
 void WarningLampManager::controlLampEmergency(const bool value)
@@ -122,6 +319,217 @@ void WarningLampManager::warningLampManager(
       controlLampWarning(true);
       controlLampEmergency(false);
       break;
+  }
+}
+
+void WarningLampManager::setEngageProcess(bool request, bool accept)
+{
+  /* In multi-threaded system, there is a possibility of simultaneous accesses from different
+     threads, so exclusion control is performed. Set request to "true" when we want the audio to
+     play when vehicle departs and restarts. Set accept to "true" when the audio playback is
+     complete. If you want to suspend waiting for playback to complete for some reason, set both
+     values to "false". */
+  std::lock_guard<std::shared_mutex> lock(mtx_);
+  is_engage_requesting_ = request;
+  is_engage_accepted_ = accept;
+}
+
+std::pair<bool, bool> WarningLampManager::getEngageProcess()
+{
+  /* In multi-threaded system, there is a possibility of simultaneous accesses from different
+     threads, so exclusion control is performed. Check both values to determine if the playback is
+     played, interrupted, or completed. */
+  std::pair<bool, bool> value;
+  {
+    std::shared_lock<std::shared_mutex> lock(mtx_);
+    value = std::make_pair(is_engage_requesting_, is_engage_accepted_);
+  }
+  return value;
+}
+
+bool WarningLampManager::isAutowareStateOfWaitingForRoute(void)
+{
+  if (initilization_state_ != autoware_adapi_v1_msgs::msg::LocalizationInitializationState::INITIALIZING) {
+    return false;
+  }
+  if (routing_state_ != autoware_adapi_v1_msgs::msg::RouteState::UNSET) {
+    return false;
+  }
+
+  return true;
+}
+
+bool WarningLampManager::isAutowareStateOfPlanning(void)
+{
+  if (routing_state_ != autoware_adapi_v1_msgs::msg::RouteState::SET) {
+    return false;
+  }
+
+  return true;
+}
+
+bool WarningLampManager::isAutowareStateOfWaitingForEngage(void)
+{
+  if(operation_state_.mode != autoware_adapi_v1_msgs::msg::OperationModeState::AUTONOMOUS) {
+    return false;
+  }
+  if (routing_state_ != autoware_adapi_v1_msgs::msg::RouteState::SET) {
+    return false;
+  }
+
+  return true;
+}
+
+bool WarningLampManager::isAutowareStateOfDriving(void)
+{
+  if(operation_state_.mode != autoware_adapi_v1_msgs::msg::OperationModeState::AUTONOMOUS) {
+    return false;
+  }
+
+  return true;
+}
+
+bool WarningLampManager::isAutowareStateOfArrivedGoal(void)
+{
+  if (routing_state_ != autoware_adapi_v1_msgs::msg::RouteState::ARRIVED) {
+    return false;
+  }
+
+  // flag_arrived_state_machine_ = true;
+  return true;
+}
+
+
+bool WarningLampManager::checkStateInformEngage(void)
+{
+  if (isAutowareStateOfDriving() != true){
+    return false;
+  }
+
+  if (service_layer_state_ == autoware_state_machine_msgs::msg::StateMachine::STATE_WAITING_ENGAGE_INSTRUCTION) {
+    if (flag_calls_vehicle_voice_ == true || delivery_reservation_state_ == autoware_state_machine_msgs::msg::StateLock::STATE_ON) {
+      return false;
+    }
+  }
+
+  auto [is_request, is_accept] = getEngageProcess();
+  if (is_request == false || delivery_reservation_state_ == autoware_state_machine_msgs::msg::StateLock::STATE_VERIFICATION) {
+      return false;
+  }
+
+  return true;
+}
+
+bool WarningLampManager::checkStateInformRestart(void)
+{
+  if (isAutowareStateOfDriving() != true){
+    return false;
+  }
+
+  /* If restart is requested, voice guidance will be played. */
+  auto [is_request, is_accept] = getEngageProcess();
+  if (!is_request || is_accept) {  
+    return false;
+  }
+
+  return true;
+}
+
+bool WarningLampManager::checkState4DuringReceiveRoute(void)
+{
+  if (isAutowareStateOfWaitingForRoute() != true &&
+      isAutowareStateOfPlanning() != true){
+    return false;
+  }
+
+  return true;
+}
+
+bool WarningLampManager::checkStateWaitingEngageInstruction(void)
+{
+  if(control_layer_state_ != autoware_state_machine_msgs::msg::StateMachine::MANUAL) {
+    return false;
+  }
+
+  if (isAutowareStateOfDriving() != true){
+    return false;
+  }
+
+  return true;
+}
+
+bool WarningLampManager::checkStateWaitingCallPermission(void)
+{
+  if (isAutowareStateOfDriving() != true){
+    return false;
+  }
+
+  // delivery_reservation_state_ は追加トピックから取得予定
+  if ((flag_calls_vehicle_voice_ != true) || 
+      (delivery_reservation_state_ != autoware_state_machine_msgs::msg::StateLock::STATE_ON)) {
+      return false;
+  }
+
+  return true;  
+}
+
+bool WarningLampManager::checkState4Arrived(void)
+{
+  if (isAutowareStateOfArrivedGoal() != true){
+    return false;
+  }
+
+  return true;  
+}
+
+void WarningLampManager::changeState(void)
+{
+  if (service_layer_state_ == autoware_state_machine_msgs::msg::StateMachine::STATE_UNDEFINED) { 
+    // STATE_CHECK_NODE_ALIVE
+    service_layer_state_ = autoware_state_machine_msgs::msg::StateMachine::STATE_CHECK_NODE_ALIVE;
+
+  } else if (em_holding_ == true) {
+    //setEngageProcess(false, false);
+    // STATE_EMERGENCY_STOP
+    service_layer_state_ = autoware_state_machine_msgs::msg::StateMachine::STATE_EMERGENCY_STOP;
+
+  } else if (checkStateInformEngage() == true) {
+    // STATE_INFORM_ENGAGE
+    //setEngageProcess(false, true);
+    service_layer_state_ = autoware_state_machine_msgs::msg::StateMachine::STATE_INFORM_ENGAGE;
+
+  } else if (checkStateInformRestart() == true) {
+    // STATE_INFORM_RESTART
+    service_layer_state_ = autoware_state_machine_msgs::msg::StateMachine::STATE_INFORM_RESTART;
+
+  } else if (checkState4DuringReceiveRoute() == true) {
+    // STATE_DURING_RECEIVE_ROUTE
+    //setEngageProcess(false, false);
+    service_layer_state_ = autoware_state_machine_msgs::msg::StateMachine::STATE_DURING_RECEIVE_ROUTE;
+
+  } else if (checkStateWaitingEngageInstruction() == true) {
+    // STATE_WAITING_ENGAGE_INSTRUCTION
+    service_layer_state_ = autoware_state_machine_msgs::msg::StateMachine::STATE_WAITING_ENGAGE_INSTRUCTION;
+
+  } else if (checkStateWaitingCallPermission() == true) {
+    // STATE_WAITING_CALL_PERMISSION
+    service_layer_state_ = autoware_state_machine_msgs::msg::StateMachine::STATE_WAITING_CALL_PERMISSION;
+
+  } else if (checkState4Arrived() == true) {
+    // STATE_ARRIVED_GOAL
+    //setEngageProcess(false, false);    
+    service_layer_state_ = autoware_state_machine_msgs::msg::StateMachine::STATE_ARRIVED_GOAL;
+
+  } else {
+    // 上記以外
+    service_layer_state_ = 0xFFFF;
+  }
+
+  if ((operation_state_.is_stop_mode_available == true) ||
+      (operation_state_.is_local_mode_available == true)) {
+    control_layer_state_ = autoware_state_machine_msgs::msg::StateMachine::MANUAL;
+  } else {
+    control_layer_state_ = autoware_state_machine_msgs::msg::StateMachine::AUTO;
   }
 }
 


### PR DESCRIPTION
## Description

autoware_state_machine削除に伴う、warning_lamp_managerの修正

## How was this PR tested?

ビルド確認済み
テスト未実施
colcon testで、動作確認予定

## Notes for reviewers

Engage状態をeve_cmd_gateノードからもらう予定ですが、ノードが未実装のため、
warning_lamp_manager内は、暫定実装にとどめ、でビルドが通る状態にしてます

## Effects on system behavior

None.