### PR TITLE
fix: remove deprecated subscriptions 

### DIFF
--- a/include/warning_lamp_manager/warning_lamp_manager.hpp
+++ b/include/warning_lamp_manager/warning_lamp_manager.hpp
@@ -18,14 +18,14 @@
 #include "rclcpp/rclcpp.hpp"
 #include "autoware_state_machine_msgs/msg/state_lock.hpp"
 #include "autoware_state_machine_msgs/msg/state_machine.hpp"
+#include "autoware_system_msgs/msg/hazard_status_stamped.hpp"
 #include "dio_ros_driver/msg/dio_port.hpp"
+#include "eve_cmd_gate_msgs/msg/engage_request_state.hpp"
 #include "go_interface_msgs/msg/vehicle_status.hpp"
 #include <autoware_adapi_v1_msgs/msg/localization_initialization_state.hpp>
-#include <autoware_adapi_v1_msgs/msg/route_state.hpp>
-#include <autoware_adapi_v1_msgs/msg/diag_graph_status.hpp>
-#include <autoware_adapi_v1_msgs/msg/diag_graph_struct.hpp>
+#include <autoware_adapi_v1_msgs/msg/motion_state.hpp>
 #include <autoware_adapi_v1_msgs/msg/operation_mode_state.hpp>
-#include <diagnostic_msgs/msg/diagnostic_status.hpp>
+#include <autoware_adapi_v1_msgs/msg/route_state.hpp>
 
 
 namespace warning_lamp_manager
@@ -44,42 +44,33 @@ private:
   rclcpp::Publisher<dio_ros_driver::msg::DIOPort>::SharedPtr pub_warning_lamp_warning_;
 
   // Subscriber
-  rclcpp::Subscription<autoware_state_machine_msgs::msg::StateMachine>::SharedPtr sub_state_;
   rclcpp::Subscription<autoware_adapi_v1_msgs::msg::LocalizationInitializationState>::SharedPtr sub_initilization_state_;
   rclcpp::Subscription<autoware_adapi_v1_msgs::msg::RouteState>::SharedPtr sub_routing_state_;
-  rclcpp::Subscription<autoware_adapi_v1_msgs::msg::DiagGraphStatus>::SharedPtr sub_daignostics_status_;
-  rclcpp::Subscription<autoware_adapi_v1_msgs::msg::DiagGraphStruct>::SharedPtr sub_daignostics_struct_;
   rclcpp::Subscription<autoware_adapi_v1_msgs::msg::OperationModeState>::SharedPtr sub_operation_mode_state_;
   rclcpp::Subscription<go_interface_msgs::msg::VehicleStatus>::SharedPtr sub_calls_vehicle_state_;
   rclcpp::Subscription<autoware_state_machine_msgs::msg::StateLock>::SharedPtr sub_delivery_reservation_state_;
-  rclcpp::Subscription<autoware_state_machine_msgs::msg::StateMachine>::SharedPtr sub_engage_process_state_;
-  
-  std::shared_mutex mtx_;
+  rclcpp::Subscription<eve_cmd_gate_msgs::msg::EngageRequestState>::SharedPtr sub_engage_process_state_;
+  rclcpp::Subscription<autoware_system_msgs::msg::HazardStatusStamped>::SharedPtr sub_hazard_status_;
+  rclcpp::Subscription<autoware_adapi_v1_msgs::msg::MotionState>::SharedPtr sub_motion_state_;
+
+  uint16_t motion_state_;
   bool is_engage_requesting_;
   bool is_engage_accepted_;
-
   bool active_polarity_;
   bool use_overridable_vehicle_;
+  bool em_holding_;
   uint16_t service_layer_state_;
   uint16_t control_layer_state_;
   uint16_t initilization_state_;
   uint16_t routing_state_;
-  uint16_t delivery_reservation_state_;  
-  std::optional<uint16_t> em_holding_indices_;
-  bool em_holding_;
+  uint16_t delivery_reservation_state_;
   autoware_adapi_v1_msgs::msg::OperationModeState operation_state_;
   bool flag_calls_vehicle_voice_;
 
-  void callbackStateMessage(
-    const autoware_state_machine_msgs::msg::StateMachine::ConstSharedPtr msg);
   void callbackAutowareInitializationMessage(
     const autoware_adapi_v1_msgs::msg::LocalizationInitializationState::ConstSharedPtr msg);
   void callbackRoutingStateMessage(
     const autoware_adapi_v1_msgs::msg::RouteState::ConstSharedPtr msg);
-  void callbackDaignosticsStructMessage(
-    const autoware_adapi_v1_msgs::msg::DiagGraphStruct::ConstSharedPtr msg);
-  void callbackDaignosticsStateMessage(
-    const autoware_adapi_v1_msgs::msg::DiagGraphStatus::ConstSharedPtr msg);
   void callbackOperationModeStateMessage(
     const autoware_adapi_v1_msgs::msg::OperationModeState::ConstSharedPtr msg);
   void callbackVehicleStateMessage(
@@ -87,13 +78,16 @@ private:
   void callbackDeliveryReservationMessage(
     const autoware_state_machine_msgs::msg::StateLock::ConstSharedPtr msg);
   void callbackEngageProcessMessage(
-    const autoware_state_machine_msgs::msg::StateMachine::ConstSharedPtr msg);
+    const eve_cmd_gate_msgs::msg::EngageRequestState::ConstSharedPtr msg);
+  void callbackHazardStatusMessage(
+    const autoware_system_msgs::msg::HazardStatusStamped::ConstSharedPtr msg);
+  void callbackMotionStateMessage(
+    const autoware_adapi_v1_msgs::msg::MotionState::ConstSharedPtr msg);
 
   void controlLampEmergency(const bool value);
   void controlLampWarning(const bool value);
   void warningLampManager(const uint16_t service_layer_state, const uint8_t control_layer_state);
   void changeState(void);
-  bool isAutowareStateOfWaitingForEngage(void);
   bool isAutowareStateOfDriving(void);
   bool isAutowareStateOfWaitingForRoute(void);
   bool isAutowareStateOfPlanning(void);
@@ -104,8 +98,6 @@ private:
   bool checkStateWaitingEngageInstruction(void);
   bool checkStateWaitingCallPermission(void);
   bool checkState4Arrived(void);
-  void setEngageProcess(bool request, bool accept);
-  std::pair<bool, bool> getEngageProcess();
 };
 
 }  // namespace warning_lamp_manager

--- a/package.xml
+++ b/package.xml
@@ -34,6 +34,8 @@
   <depend>diagnostic_msgs</depend>
   <depend>go_interface_msgs</depend>
   <depend>autoware_vehicle_msgs</depend>
+  <depend>eve_cmd_gate_msgs</depend>
+  <depend>autoware_system_msgs</depend>
 
   <depend>builtin_interfaces</depend>
 

--- a/src/warning_lamp_manager.cpp
+++ b/src/warning_lamp_manager.cpp
@@ -19,7 +19,7 @@ namespace warning_lamp_manager
 
 namespace
 {
-const char* getServiceLayerStateName(uint16_t state)
+const char * getServiceLayerStateName(uint16_t state)
 {
   switch (state) {
     case autoware_state_machine_msgs::msg::StateMachine::STATE_UNDEFINED:
@@ -48,68 +48,54 @@ const char* getServiceLayerStateName(uint16_t state)
 }
 }  // namespace
 
-WarningLampManager::WarningLampManager(
-  const rclcpp::NodeOptions & options = rclcpp::NodeOptions())
+WarningLampManager::WarningLampManager(const rclcpp::NodeOptions & options = rclcpp::NodeOptions())
 : Node("warning_lamp_manager", options)
 {
-  use_overridable_vehicle_ = this->declare_parameter<bool>(
-    "use_overridable_vehicle", true);
+  use_overridable_vehicle_ = this->declare_parameter<bool>("use_overridable_vehicle", true);
 
-  sub_initilization_state_ = this->create_subscription<autoware_adapi_v1_msgs::msg::LocalizationInitializationState>(
-    "/api/localization/initialization_state",
-    rclcpp::QoS{3}.transient_local(),
-    std::bind(&WarningLampManager::callbackAutowareInitializationMessage, this, std::placeholders::_1)
-  );
+  sub_initilization_state_ =
+    this->create_subscription<autoware_adapi_v1_msgs::msg::LocalizationInitializationState>(
+      "/api/localization/initialization_state", rclcpp::QoS{3}.transient_local(),
+      std::bind(
+        &WarningLampManager::callbackAutowareInitializationMessage, this, std::placeholders::_1));
 
   sub_routing_state_ = this->create_subscription<autoware_adapi_v1_msgs::msg::RouteState>(
-    "/api/routing/state",
-    rclcpp::QoS{3}.transient_local(),
-    std::bind(&WarningLampManager::callbackRoutingStateMessage, this, std::placeholders::_1)
-  );
+    "/api/routing/state", rclcpp::QoS{3}.transient_local(),
+    std::bind(&WarningLampManager::callbackRoutingStateMessage, this, std::placeholders::_1));
 
-  sub_operation_mode_state_ = this->create_subscription<autoware_adapi_v1_msgs::msg::OperationModeState>(
-    "/api/operation_mode/state",
-    rclcpp::QoS{3}.transient_local(),
-    std::bind(&WarningLampManager::callbackOperationModeStateMessage, this, std::placeholders::_1)
-  );
+  sub_operation_mode_state_ =
+    this->create_subscription<autoware_adapi_v1_msgs::msg::OperationModeState>(
+      "/api/operation_mode/state", rclcpp::QoS{3}.transient_local(),
+      std::bind(
+        &WarningLampManager::callbackOperationModeStateMessage, this, std::placeholders::_1));
 
   // vehicle_status
   sub_calls_vehicle_state_ = this->create_subscription<go_interface_msgs::msg::VehicleStatus>(
-    "api_vehicle_status",
-    rclcpp::QoS{3}.transient_local(),
-    std::bind(&WarningLampManager::callbackVehicleStateMessage, this, std::placeholders::_1)
-  );
+    "api_vehicle_status", rclcpp::QoS{3}.transient_local(),
+    std::bind(&WarningLampManager::callbackVehicleStateMessage, this, std::placeholders::_1));
 
-  sub_delivery_reservation_state_ = this->create_subscription<autoware_state_machine_msgs::msg::StateLock>(
-    "/go_interface/lock_state",
-    rclcpp::QoS{3}.transient_local(),
-    std::bind(&WarningLampManager::callbackDeliveryReservationMessage, this, std::placeholders::_1)
-  );
+  sub_delivery_reservation_state_ =
+    this->create_subscription<autoware_state_machine_msgs::msg::StateLock>(
+      "/go_interface/lock_state", rclcpp::QoS{3}.transient_local(),
+      std::bind(
+        &WarningLampManager::callbackDeliveryReservationMessage, this, std::placeholders::_1));
 
   sub_engage_process_state_ = this->create_subscription<eve_cmd_gate_msgs::msg::EngageRequestState>(
-    "/eve_cmd_gate/engage_request_state",
-    rclcpp::QoS{3}.transient_local(),
-    std::bind(&WarningLampManager::callbackEngageProcessMessage, this, std::placeholders::_1)
-  );
+    "/eve_cmd_gate/engage_request_state", rclcpp::QoS{3}.transient_local(),
+    std::bind(&WarningLampManager::callbackEngageProcessMessage, this, std::placeholders::_1));
 
   sub_hazard_status_ = this->create_subscription<autoware_system_msgs::msg::HazardStatusStamped>(
-    "/system/emergency/hazard_status",
-    rclcpp::QoS{3}.transient_local(),
-    std::bind(&WarningLampManager::callbackHazardStatusMessage, this, std::placeholders::_1)
-  );
+    "/system/emergency/hazard_status", rclcpp::QoS{3}.transient_local(),
+    std::bind(&WarningLampManager::callbackHazardStatusMessage, this, std::placeholders::_1));
 
   sub_motion_state_ = this->create_subscription<autoware_adapi_v1_msgs::msg::MotionState>(
-    "/api/motion/state",
-    rclcpp::QoS{3}.transient_local(),
-    std::bind(&WarningLampManager::callbackMotionStateMessage, this, std::placeholders::_1)
-  );
+    "/api/motion/state", rclcpp::QoS{3}.transient_local(),
+    std::bind(&WarningLampManager::callbackMotionStateMessage, this, std::placeholders::_1));
 
   pub_warning_lamp_emergency_ = this->create_publisher<dio_ros_driver::msg::DIOPort>(
-    "lamp_emergency_out",
-    rclcpp::QoS{3}.transient_local());
+    "lamp_emergency_out", rclcpp::QoS{3}.transient_local());
   pub_warning_lamp_warning_ = this->create_publisher<dio_ros_driver::msg::DIOPort>(
-    "lamp_warning_out",
-    rclcpp::QoS{3}.transient_local());
+    "lamp_warning_out", rclcpp::QoS{3}.transient_local());
 
   active_polarity_ = ACTIVE_POLARITY;
   em_holding_ = false;
@@ -140,10 +126,8 @@ void WarningLampManager::callbackAutowareInitializationMessage(
   const autoware_adapi_v1_msgs::msg::LocalizationInitializationState::ConstSharedPtr msg)
 {
   RCLCPP_INFO_THROTTLE(
-    this->get_logger(),
-    *this->get_clock(), 1.0,
-    "[WarningLampManager::callbackAutowareInitializationMessage]autoware_state: %u",
-    msg->state);
+    this->get_logger(), *this->get_clock(), 1.0,
+    "[WarningLampManager::callbackAutowareInitializationMessage]autoware_state: %u", msg->state);
 
   initilization_state_ = msg->state;
 
@@ -155,10 +139,8 @@ void WarningLampManager::callbackRoutingStateMessage(
   const autoware_adapi_v1_msgs::msg::RouteState::ConstSharedPtr msg)
 {
   RCLCPP_INFO_THROTTLE(
-    this->get_logger(),
-    *this->get_clock(), 1.0,
-    "[WarningLampManager::callbackRoutingStateMessage]routing_state: %u",
-    msg->state);
+    this->get_logger(), *this->get_clock(), 1.0,
+    "[WarningLampManager::callbackRoutingStateMessage]routing_state: %u", msg->state);
 
   routing_state_ = msg->state;
 
@@ -171,10 +153,8 @@ void WarningLampManager::callbackOperationModeStateMessage(
 {
   operation_state_ = *msg;
   RCLCPP_INFO_THROTTLE(
-    this->get_logger(),
-    *this->get_clock(), 1.0,
-    "[WarningLampManager::callbackOperationModeStateMessage]operation mode: %u",
-      msg->mode);
+    this->get_logger(), *this->get_clock(), 1.0,
+    "[WarningLampManager::callbackOperationModeStateMessage]operation mode: %u", msg->mode);
 
   changeState();
   warningLampManager(service_layer_state_, control_layer_state_);
@@ -185,10 +165,8 @@ void WarningLampManager::callbackVehicleStateMessage(
 {
   flag_calls_vehicle_voice_ = msg->voice_flg;
   RCLCPP_INFO_THROTTLE(
-    this->get_logger(),
-    *this->get_clock(), 1.0,
-    "[WarningLampManager::callbackOperationModeStateMessage]vheicle voice: %u",
-      msg->voice_flg);
+    this->get_logger(), *this->get_clock(), 1.0,
+    "[WarningLampManager::callbackOperationModeStateMessage]vheicle voice: %u", msg->voice_flg);
 
   changeState();
   warningLampManager(service_layer_state_, control_layer_state_);
@@ -198,8 +176,7 @@ void WarningLampManager::callbackDeliveryReservationMessage(
   const autoware_state_machine_msgs::msg::StateLock::ConstSharedPtr msg)
 {
   RCLCPP_INFO_THROTTLE(
-    this->get_logger(),
-    *this->get_clock(), 1.0,
+    this->get_logger(), *this->get_clock(), 1.0,
     "[WarningLampManager::callbackDeliveryReservationMessage]"
     "StateLock: %u",
     msg->state);
@@ -213,8 +190,7 @@ void WarningLampManager::callbackEngageProcessMessage(
   const eve_cmd_gate_msgs::msg::EngageRequestState::ConstSharedPtr msg)
 {
   RCLCPP_INFO_THROTTLE(
-    this->get_logger(),
-    *this->get_clock(), 1.0,
+    this->get_logger(), *this->get_clock(), 1.0,
     "[WarningLampManager::callbackEngageProcessMessage]engage_request_state: %u, %u",
     msg->is_engage_requesting, msg->is_engage_accepted);
 
@@ -229,8 +205,7 @@ void WarningLampManager::callbackHazardStatusMessage(
 {
   em_holding_ = msg->status.emergency_holding;
   RCLCPP_INFO_THROTTLE(
-    this->get_logger(),
-    *this->get_clock(), 1.0,
+    this->get_logger(), *this->get_clock(), 1.0,
     "[WarningLampManager::callbackHazardStatusMessage]emergency_holding: %s",
     em_holding_ ? "true" : "false");
 
@@ -243,10 +218,8 @@ void WarningLampManager::callbackMotionStateMessage(
 {
   motion_state_ = msg->state;
   RCLCPP_INFO_THROTTLE(
-    this->get_logger(),
-    *this->get_clock(), 1.0,
-    "[WarningLampManager::callbackMotionStateMessage]motion_state: %u",
-    motion_state_);
+    this->get_logger(), *this->get_clock(), 1.0,
+    "[WarningLampManager::callbackMotionStateMessage]motion_state: %u", motion_state_);
 
   changeState();
   warningLampManager(service_layer_state_, control_layer_state_);
@@ -295,9 +268,9 @@ void WarningLampManager::warningLampManager(
     case autoware_state_machine_msgs::msg::StateMachine::STATE_WAITING_ENGAGE_INSTRUCTION:
     case autoware_state_machine_msgs::msg::StateMachine::STATE_WAITING_CALL_PERMISSION:
     case autoware_state_machine_msgs::msg::StateMachine::STATE_ARRIVED_GOAL:
-      if (use_overridable_vehicle_ ||
-        (control_layer_state == autoware_state_machine_msgs::msg::StateMachine::MANUAL))
-      {
+      if (
+        use_overridable_vehicle_ ||
+        (control_layer_state == autoware_state_machine_msgs::msg::StateMachine::MANUAL)) {
         controlLampWarning(true);
         controlLampEmergency(false);
       } else {
@@ -315,18 +288,21 @@ void WarningLampManager::warningLampManager(
 
 bool WarningLampManager::isAutowareStateOfWaitingForRoute(void)
 {
-  return initilization_state_ == autoware_adapi_v1_msgs::msg::LocalizationInitializationState::INITIALIZED &&
+  return initilization_state_ ==
+           autoware_adapi_v1_msgs::msg::LocalizationInitializationState::INITIALIZED &&
          routing_state_ == autoware_adapi_v1_msgs::msg::RouteState::UNSET;
 }
 
 bool WarningLampManager::isAutowareStateOfPlanning(void)
 {
-  return routing_state_ == autoware_adapi_v1_msgs::msg::RouteState::SET && operation_state_.is_autonomous_mode_available;
+  return routing_state_ == autoware_adapi_v1_msgs::msg::RouteState::SET &&
+         operation_state_.is_autonomous_mode_available;
 }
 
 bool WarningLampManager::isAutowareStateOfDriving(void)
 {
-  return operation_state_.mode == autoware_adapi_v1_msgs::msg::OperationModeState::AUTONOMOUS && motion_state_ == autoware_adapi_v1_msgs::msg::MotionState::MOVING;
+  return operation_state_.mode == autoware_adapi_v1_msgs::msg::OperationModeState::AUTONOMOUS &&
+         motion_state_ == autoware_adapi_v1_msgs::msg::MotionState::MOVING;
 }
 
 bool WarningLampManager::isAutowareStateOfArrivedGoal(void)
@@ -334,18 +310,17 @@ bool WarningLampManager::isAutowareStateOfArrivedGoal(void)
   return routing_state_ == autoware_adapi_v1_msgs::msg::RouteState::ARRIVED;
 }
 
-
 bool WarningLampManager::checkStateInformEngage(void)
 {
-  return operation_state_.mode == autoware_adapi_v1_msgs::msg::OperationModeState::AUTONOMOUS && operation_state_.is_autoware_control_enabled && motion_state_ == autoware_adapi_v1_msgs::msg::MotionState::STARTING;
+  return operation_state_.mode == autoware_adapi_v1_msgs::msg::OperationModeState::AUTONOMOUS &&
+         operation_state_.is_autoware_control_enabled &&
+         motion_state_ == autoware_adapi_v1_msgs::msg::MotionState::STARTING;
 }
 
 bool WarningLampManager::checkStateInformRestart(void)
 {
   return is_engage_requesting_ && !is_engage_accepted_;
 }
-
-## 
 
 bool WarningLampManager::checkState4DuringReceiveRoute(void)
 {
@@ -354,13 +329,13 @@ bool WarningLampManager::checkState4DuringReceiveRoute(void)
 
 bool WarningLampManager::checkStateWaitingEngageInstruction(void)
 {
-  return operation_state_.mode == autoware_adapi_v1_msgs::msg::OperationModeState::STOP && routing_state_ == autoware_adapi_v1_msgs::msg::RouteState::SET;
+  return operation_state_.mode == autoware_adapi_v1_msgs::msg::OperationModeState::STOP &&
+         routing_state_ == autoware_adapi_v1_msgs::msg::RouteState::SET;
 }
 
 bool WarningLampManager::checkStateWaitingCallPermission(void)
 {
-  return isAutowareStateOfDriving() &&
-         flag_calls_vehicle_voice_ &&
+  return isAutowareStateOfDriving() && flag_calls_vehicle_voice_ &&
          delivery_reservation_state_ == autoware_state_machine_msgs::msg::StateLock::STATE_ON;
 }
 
@@ -380,11 +355,14 @@ void WarningLampManager::changeState(void)
   } else if (checkStateInformRestart()) {
     service_layer_state_ = autoware_state_machine_msgs::msg::StateMachine::STATE_INFORM_RESTART;
   } else if (checkState4DuringReceiveRoute()) {
-    service_layer_state_ = autoware_state_machine_msgs::msg::StateMachine::STATE_DURING_RECEIVE_ROUTE;
+    service_layer_state_ =
+      autoware_state_machine_msgs::msg::StateMachine::STATE_DURING_RECEIVE_ROUTE;
   } else if (checkStateWaitingEngageInstruction()) {
-    service_layer_state_ = autoware_state_machine_msgs::msg::StateMachine::STATE_WAITING_ENGAGE_INSTRUCTION;
+    service_layer_state_ =
+      autoware_state_machine_msgs::msg::StateMachine::STATE_WAITING_ENGAGE_INSTRUCTION;
   } else if (checkStateWaitingCallPermission()) {
-    service_layer_state_ = autoware_state_machine_msgs::msg::StateMachine::STATE_WAITING_CALL_PERMISSION;
+    service_layer_state_ =
+      autoware_state_machine_msgs::msg::StateMachine::STATE_WAITING_CALL_PERMISSION;
   } else if (checkState4Arrived()) {
     service_layer_state_ = autoware_state_machine_msgs::msg::StateMachine::STATE_ARRIVED_GOAL;
   } else {
@@ -398,14 +376,13 @@ void WarningLampManager::changeState(void)
   }
 
   RCLCPP_INFO_THROTTLE(
-    this->get_logger(),
-    *this->get_clock(), 1.0,
+    this->get_logger(), *this->get_clock(), 1.0,
     "[WarningLampManager::changeState] service_layer_state: %s, control_layer_state: %s, "
     "operation_mode: %u, motion_state: %u, is_autoware_control_enabled: %s, em_holding: %s",
     getServiceLayerStateName(service_layer_state_),
-    control_layer_state_ == autoware_state_machine_msgs::msg::StateMachine::MANUAL ? "MANUAL" : "AUTO",
-    operation_state_.mode,
-    motion_state_,
+    control_layer_state_ == autoware_state_machine_msgs::msg::StateMachine::MANUAL ? "MANUAL"
+                                                                                   : "AUTO",
+    operation_state_.mode, motion_state_,
     operation_state_.is_autoware_control_enabled ? "true" : "false",
     em_holding_ ? "true" : "false");
 }

--- a/src/warning_lamp_manager.cpp
+++ b/src/warning_lamp_manager.cpp
@@ -12,12 +12,41 @@
 // See the License for the specific language governing permissions and
 // limitations under the License
 
-#include <fstream>
-
 #include "warning_lamp_manager/warning_lamp_manager.hpp"
 
 namespace warning_lamp_manager
 {
+
+namespace
+{
+const char* getServiceLayerStateName(uint16_t state)
+{
+  switch (state) {
+    case autoware_state_machine_msgs::msg::StateMachine::STATE_UNDEFINED:
+      return "STATE_UNDEFINED";
+    case autoware_state_machine_msgs::msg::StateMachine::STATE_CHECK_NODE_ALIVE:
+      return "STATE_CHECK_NODE_ALIVE";
+    case autoware_state_machine_msgs::msg::StateMachine::STATE_EMERGENCY_STOP:
+      return "STATE_EMERGENCY_STOP";
+    case autoware_state_machine_msgs::msg::StateMachine::STATE_INFORM_ENGAGE:
+      return "STATE_INFORM_ENGAGE";
+    case autoware_state_machine_msgs::msg::StateMachine::STATE_INFORM_RESTART:
+      return "STATE_INFORM_RESTART";
+    case autoware_state_machine_msgs::msg::StateMachine::STATE_DURING_RECEIVE_ROUTE:
+      return "STATE_DURING_RECEIVE_ROUTE";
+    case autoware_state_machine_msgs::msg::StateMachine::STATE_WAITING_ENGAGE_INSTRUCTION:
+      return "STATE_WAITING_ENGAGE_INSTRUCTION";
+    case autoware_state_machine_msgs::msg::StateMachine::STATE_WAITING_CALL_PERMISSION:
+      return "STATE_WAITING_CALL_PERMISSION";
+    case autoware_state_machine_msgs::msg::StateMachine::STATE_ARRIVED_GOAL:
+      return "STATE_ARRIVED_GOAL";
+    case autoware_state_machine_msgs::msg::StateMachine::STATE_DRIVING:
+      return "STATE_DRIVING";
+    default:
+      return "UNKNOWN";
+  }
+}
+}  // namespace
 
 WarningLampManager::WarningLampManager(
   const rclcpp::NodeOptions & options = rclcpp::NodeOptions())
@@ -26,39 +55,18 @@ WarningLampManager::WarningLampManager(
   use_overridable_vehicle_ = this->declare_parameter<bool>(
     "use_overridable_vehicle", true);
 
-  sub_state_ = this->create_subscription<autoware_state_machine_msgs::msg::StateMachine>(
-    "autoware_state_machine/state",
-    rclcpp::QoS{3}.transient_local(),
-    std::bind(&WarningLampManager::callbackStateMessage, this, std::placeholders::_1)
-  );
-
-  // autoware_state
   sub_initilization_state_ = this->create_subscription<autoware_adapi_v1_msgs::msg::LocalizationInitializationState>(
     "/api/localization/initialization_state",
     rclcpp::QoS{3}.transient_local(),
     std::bind(&WarningLampManager::callbackAutowareInitializationMessage, this, std::placeholders::_1)
   );
 
-  // routing wait state
   sub_routing_state_ = this->create_subscription<autoware_adapi_v1_msgs::msg::RouteState>(
     "/api/routing/state",
     rclcpp::QoS{3}.transient_local(),
     std::bind(&WarningLampManager::callbackRoutingStateMessage, this, std::placeholders::_1)
   );
 
-  // daignostics struct for EM Holding
-  sub_daignostics_struct_ = this->create_subscription<autoware_adapi_v1_msgs::msg::DiagGraphStruct>(
-    "/api/system/diagnostics/struct",
-    rclcpp::QoS{3}.transient_local(),
-    std::bind(&WarningLampManager::callbackDaignosticsStructMessage, this, std::placeholders::_1)
-  );
-  sub_daignostics_status_ = this->create_subscription<autoware_adapi_v1_msgs::msg::DiagGraphStatus>(
-    "/api/system/diagnostics/status",
-    rclcpp::QoS{3}.transient_local(),
-    std::bind(&WarningLampManager::callbackDaignosticsStateMessage, this, std::placeholders::_1)
-  );
-
-  // OperationModeState
   sub_operation_mode_state_ = this->create_subscription<autoware_adapi_v1_msgs::msg::OperationModeState>(
     "/api/operation_mode/state",
     rclcpp::QoS{3}.transient_local(),
@@ -72,19 +80,28 @@ WarningLampManager::WarningLampManager(
     std::bind(&WarningLampManager::callbackVehicleStateMessage, this, std::placeholders::_1)
   );
 
-  // delivery reservation state
   sub_delivery_reservation_state_ = this->create_subscription<autoware_state_machine_msgs::msg::StateLock>(
     "/go_interface/lock_state",
     rclcpp::QoS{3}.transient_local(),
     std::bind(&WarningLampManager::callbackDeliveryReservationMessage, this, std::placeholders::_1)
   );
 
-  // TODO:eve_cmd_gateからengage状態をもらう、topic名とメッセージ型を反映
-  // engage process state
-  sub_engage_process_state_ = this->create_subscription<autoware_state_machine_msgs::msg::StateMachine>(
-    "xxxxx/xxxx",
+  sub_engage_process_state_ = this->create_subscription<eve_cmd_gate_msgs::msg::EngageRequestState>(
+    "/eve_cmd_gate/engage_request_state",
     rclcpp::QoS{3}.transient_local(),
     std::bind(&WarningLampManager::callbackEngageProcessMessage, this, std::placeholders::_1)
+  );
+
+  sub_hazard_status_ = this->create_subscription<autoware_system_msgs::msg::HazardStatusStamped>(
+    "/system/emergency/hazard_status",
+    rclcpp::QoS{3}.transient_local(),
+    std::bind(&WarningLampManager::callbackHazardStatusMessage, this, std::placeholders::_1)
+  );
+
+  sub_motion_state_ = this->create_subscription<autoware_adapi_v1_msgs::msg::MotionState>(
+    "/api/motion/state",
+    rclcpp::QoS{3}.transient_local(),
+    std::bind(&WarningLampManager::callbackMotionStateMessage, this, std::placeholders::_1)
   );
 
   pub_warning_lamp_emergency_ = this->create_publisher<dio_ros_driver::msg::DIOPort>(
@@ -95,13 +112,13 @@ WarningLampManager::WarningLampManager(
     rclcpp::QoS{3}.transient_local());
 
   active_polarity_ = ACTIVE_POLARITY;
-  em_holding_indices_ = std::nullopt;
+  em_holding_ = false;
+  motion_state_ = autoware_adapi_v1_msgs::msg::MotionState::UNKNOWN;
   service_layer_state_ = autoware_state_machine_msgs::msg::StateMachine::STATE_UNDEFINED;
   control_layer_state_ = autoware_state_machine_msgs::msg::StateMachine::MANUAL;
   initilization_state_ = autoware_adapi_v1_msgs::msg::LocalizationInitializationState::UNKNOWN;
   routing_state_ = autoware_adapi_v1_msgs::msg::RouteState::UNKNOWN;
   delivery_reservation_state_ = autoware_state_machine_msgs::msg::StateLock::STATE_OFF;
-  em_holding_ = false;
   operation_state_.is_autoware_control_enabled = false;
   operation_state_.is_in_transition = false;
   operation_state_.is_stop_mode_available = false;
@@ -117,20 +134,6 @@ WarningLampManager::~WarningLampManager()
 {
   controlLampWarning(false);
   controlLampEmergency(false);
-}
-
-void WarningLampManager::callbackStateMessage(
-  const autoware_state_machine_msgs::msg::StateMachine::ConstSharedPtr msg)
-{
-  RCLCPP_INFO_THROTTLE(
-    this->get_logger(),
-    *this->get_clock(), 1.0,
-    "[WarningLampManager::callbackStateMessage]"
-    "service_layer_state: %u, control_layer_state: %u",
-    msg->service_layer_state,
-    msg->control_layer_state);
-
-  warningLampManager(msg->service_layer_state, msg->control_layer_state);
 }
 
 void WarningLampManager::callbackAutowareInitializationMessage(
@@ -161,45 +164,6 @@ void WarningLampManager::callbackRoutingStateMessage(
 
   changeState();
   warningLampManager(service_layer_state_, control_layer_state_);
-}
-
-void WarningLampManager::callbackDaignosticsStructMessage(
-  const autoware_adapi_v1_msgs::msg::DiagGraphStruct::ConstSharedPtr msg)
-{
-  auto nodes = msg->nodes;
-
-  for (uint16_t i = 0; i < nodes.size(); ++i) {
-    if (nodes[i].path == "/autoware/modes/autonomous") {
-      em_holding_indices_ = i;
-      RCLCPP_INFO_THROTTLE(
-        this->get_logger(),
-        *this->get_clock(), 1.0,
-        "[WarningLampManager::callbackDaignosticsStructMessage]daignostics_graph /autoware/modes/autonomous index: %u", i);
-      break;
-    }
-  }
-}
-
-void WarningLampManager::callbackDaignosticsStateMessage(
-  const autoware_adapi_v1_msgs::msg::DiagGraphStatus::ConstSharedPtr msg)
-{
-  auto nodes = msg->nodes;
-  if (em_holding_indices_ != std::nullopt) {
-    // TODO:Ph3にて、levelをlatch_levelに変更
-    if (nodes[em_holding_indices_.value()].level == diagnostic_msgs::msg::DiagnosticStatus::ERROR) {
-      em_holding_ = true;
-      RCLCPP_INFO_THROTTLE(
-        this->get_logger(),
-        *this->get_clock(), 1.0,
-        "[WarningLampManager::callbackDaignosticsStateMessage]/autoware/modes/autonomous latch_level: %u",
-        nodes[em_holding_indices_.value()].level);// TODO:Ph3にて、levelをlatch_levelに変更
-    } else {
-      em_holding_ = false;
-    }
-
-    changeState();
-    warningLampManager(service_layer_state_, control_layer_state_);
-  }
 }
 
 void WarningLampManager::callbackOperationModeStateMessage(
@@ -246,17 +210,44 @@ void WarningLampManager::callbackDeliveryReservationMessage(
 }
 
 void WarningLampManager::callbackEngageProcessMessage(
-  const autoware_state_machine_msgs::msg::StateMachine::ConstSharedPtr msg)
+  const eve_cmd_gate_msgs::msg::EngageRequestState::ConstSharedPtr msg)
 {
   RCLCPP_INFO_THROTTLE(
     this->get_logger(),
     *this->get_clock(), 1.0,
-    "[WarningLampManager::callbackEngageProcessMessage]"
-    "request: %u, accept: %u",
-    msg->service_layer_state, msg->control_layer_state);
-//    msg->request, msg->accept);
+    "[WarningLampManager::callbackEngageProcessMessage]engage_request_state: %u, %u",
+    msg->is_engage_requesting, msg->is_engage_accepted);
 
-  //setEngageProcess(msg->request, msg->accept);
+  is_engage_requesting_ = msg->is_engage_requesting;
+  is_engage_accepted_ = msg->is_engage_accepted;
+  changeState();
+  warningLampManager(service_layer_state_, control_layer_state_);
+}
+
+void WarningLampManager::callbackHazardStatusMessage(
+  const autoware_system_msgs::msg::HazardStatusStamped::ConstSharedPtr msg)
+{
+  em_holding_ = msg->status.emergency_holding;
+  RCLCPP_INFO_THROTTLE(
+    this->get_logger(),
+    *this->get_clock(), 1.0,
+    "[WarningLampManager::callbackHazardStatusMessage]emergency_holding: %s",
+    em_holding_ ? "true" : "false");
+
+  changeState();
+  warningLampManager(service_layer_state_, control_layer_state_);
+}
+
+void WarningLampManager::callbackMotionStateMessage(
+  const autoware_adapi_v1_msgs::msg::MotionState::ConstSharedPtr msg)
+{
+  motion_state_ = msg->state;
+  RCLCPP_INFO_THROTTLE(
+    this->get_logger(),
+    *this->get_clock(), 1.0,
+    "[WarningLampManager::callbackMotionStateMessage]motion_state: %u",
+    motion_state_);
+
   changeState();
   warningLampManager(service_layer_state_, control_layer_state_);
 }
@@ -322,215 +313,101 @@ void WarningLampManager::warningLampManager(
   }
 }
 
-void WarningLampManager::setEngageProcess(bool request, bool accept)
-{
-  /* In multi-threaded system, there is a possibility of simultaneous accesses from different
-     threads, so exclusion control is performed. Set request to "true" when we want the audio to
-     play when vehicle departs and restarts. Set accept to "true" when the audio playback is
-     complete. If you want to suspend waiting for playback to complete for some reason, set both
-     values to "false". */
-  std::lock_guard<std::shared_mutex> lock(mtx_);
-  is_engage_requesting_ = request;
-  is_engage_accepted_ = accept;
-}
-
-std::pair<bool, bool> WarningLampManager::getEngageProcess()
-{
-  /* In multi-threaded system, there is a possibility of simultaneous accesses from different
-     threads, so exclusion control is performed. Check both values to determine if the playback is
-     played, interrupted, or completed. */
-  std::pair<bool, bool> value;
-  {
-    std::shared_lock<std::shared_mutex> lock(mtx_);
-    value = std::make_pair(is_engage_requesting_, is_engage_accepted_);
-  }
-  return value;
-}
-
 bool WarningLampManager::isAutowareStateOfWaitingForRoute(void)
 {
-  if (initilization_state_ != autoware_adapi_v1_msgs::msg::LocalizationInitializationState::INITIALIZING) {
-    return false;
-  }
-  if (routing_state_ != autoware_adapi_v1_msgs::msg::RouteState::UNSET) {
-    return false;
-  }
-
-  return true;
+  return initilization_state_ == autoware_adapi_v1_msgs::msg::LocalizationInitializationState::INITIALIZED &&
+         routing_state_ == autoware_adapi_v1_msgs::msg::RouteState::UNSET;
 }
 
 bool WarningLampManager::isAutowareStateOfPlanning(void)
 {
-  if (routing_state_ != autoware_adapi_v1_msgs::msg::RouteState::SET) {
-    return false;
-  }
-
-  return true;
-}
-
-bool WarningLampManager::isAutowareStateOfWaitingForEngage(void)
-{
-  if(operation_state_.mode != autoware_adapi_v1_msgs::msg::OperationModeState::AUTONOMOUS) {
-    return false;
-  }
-  if (routing_state_ != autoware_adapi_v1_msgs::msg::RouteState::SET) {
-    return false;
-  }
-
-  return true;
+  return routing_state_ == autoware_adapi_v1_msgs::msg::RouteState::SET && operation_state_.is_autonomous_mode_available;
 }
 
 bool WarningLampManager::isAutowareStateOfDriving(void)
 {
-  if(operation_state_.mode != autoware_adapi_v1_msgs::msg::OperationModeState::AUTONOMOUS) {
-    return false;
-  }
-
-  return true;
+  return operation_state_.mode == autoware_adapi_v1_msgs::msg::OperationModeState::AUTONOMOUS && motion_state_ == autoware_adapi_v1_msgs::msg::MotionState::MOVING;
 }
 
 bool WarningLampManager::isAutowareStateOfArrivedGoal(void)
 {
-  if (routing_state_ != autoware_adapi_v1_msgs::msg::RouteState::ARRIVED) {
-    return false;
-  }
-
-  // flag_arrived_state_machine_ = true;
-  return true;
+  return routing_state_ == autoware_adapi_v1_msgs::msg::RouteState::ARRIVED;
 }
 
 
 bool WarningLampManager::checkStateInformEngage(void)
 {
-  if (isAutowareStateOfDriving() != true){
-    return false;
-  }
-
-  if (service_layer_state_ == autoware_state_machine_msgs::msg::StateMachine::STATE_WAITING_ENGAGE_INSTRUCTION) {
-    if (flag_calls_vehicle_voice_ == true || delivery_reservation_state_ == autoware_state_machine_msgs::msg::StateLock::STATE_ON) {
-      return false;
-    }
-  }
-
-  auto [is_request, is_accept] = getEngageProcess();
-  if (is_request == false || delivery_reservation_state_ == autoware_state_machine_msgs::msg::StateLock::STATE_VERIFICATION) {
-      return false;
-  }
-
-  return true;
+  return operation_state_.mode == autoware_adapi_v1_msgs::msg::OperationModeState::AUTONOMOUS && operation_state_.is_autoware_control_enabled && motion_state_ == autoware_adapi_v1_msgs::msg::MotionState::STARTING;
 }
 
 bool WarningLampManager::checkStateInformRestart(void)
 {
-  if (isAutowareStateOfDriving() != true){
-    return false;
-  }
-
-  /* If restart is requested, voice guidance will be played. */
-  auto [is_request, is_accept] = getEngageProcess();
-  if (!is_request || is_accept) {  
-    return false;
-  }
-
-  return true;
+  return is_engage_requesting_ && !is_engage_accepted_;
 }
+
+## 
 
 bool WarningLampManager::checkState4DuringReceiveRoute(void)
 {
-  if (isAutowareStateOfWaitingForRoute() != true &&
-      isAutowareStateOfPlanning() != true){
-    return false;
-  }
-
-  return true;
+  return isAutowareStateOfWaitingForRoute();
 }
 
 bool WarningLampManager::checkStateWaitingEngageInstruction(void)
 {
-  if(control_layer_state_ != autoware_state_machine_msgs::msg::StateMachine::MANUAL) {
-    return false;
-  }
-
-  if (isAutowareStateOfDriving() != true){
-    return false;
-  }
-
-  return true;
+  return operation_state_.mode == autoware_adapi_v1_msgs::msg::OperationModeState::STOP && routing_state_ == autoware_adapi_v1_msgs::msg::RouteState::SET;
 }
 
 bool WarningLampManager::checkStateWaitingCallPermission(void)
 {
-  if (isAutowareStateOfDriving() != true){
-    return false;
-  }
-
-  // delivery_reservation_state_ は追加トピックから取得予定
-  if ((flag_calls_vehicle_voice_ != true) || 
-      (delivery_reservation_state_ != autoware_state_machine_msgs::msg::StateLock::STATE_ON)) {
-      return false;
-  }
-
-  return true;  
+  return isAutowareStateOfDriving() &&
+         flag_calls_vehicle_voice_ &&
+         delivery_reservation_state_ == autoware_state_machine_msgs::msg::StateLock::STATE_ON;
 }
 
 bool WarningLampManager::checkState4Arrived(void)
 {
-  if (isAutowareStateOfArrivedGoal() != true){
-    return false;
-  }
-
-  return true;  
+  return isAutowareStateOfArrivedGoal();
 }
 
 void WarningLampManager::changeState(void)
 {
-  if (service_layer_state_ == autoware_state_machine_msgs::msg::StateMachine::STATE_UNDEFINED) { 
-    // STATE_CHECK_NODE_ALIVE
+  if (service_layer_state_ == autoware_state_machine_msgs::msg::StateMachine::STATE_UNDEFINED) {
     service_layer_state_ = autoware_state_machine_msgs::msg::StateMachine::STATE_CHECK_NODE_ALIVE;
-
-  } else if (em_holding_ == true) {
-    //setEngageProcess(false, false);
-    // STATE_EMERGENCY_STOP
+  } else if (em_holding_) {
     service_layer_state_ = autoware_state_machine_msgs::msg::StateMachine::STATE_EMERGENCY_STOP;
-
-  } else if (checkStateInformEngage() == true) {
-    // STATE_INFORM_ENGAGE
-    //setEngageProcess(false, true);
+  } else if (checkStateInformEngage()) {
     service_layer_state_ = autoware_state_machine_msgs::msg::StateMachine::STATE_INFORM_ENGAGE;
-
-  } else if (checkStateInformRestart() == true) {
-    // STATE_INFORM_RESTART
+  } else if (checkStateInformRestart()) {
     service_layer_state_ = autoware_state_machine_msgs::msg::StateMachine::STATE_INFORM_RESTART;
-
-  } else if (checkState4DuringReceiveRoute() == true) {
-    // STATE_DURING_RECEIVE_ROUTE
-    //setEngageProcess(false, false);
+  } else if (checkState4DuringReceiveRoute()) {
     service_layer_state_ = autoware_state_machine_msgs::msg::StateMachine::STATE_DURING_RECEIVE_ROUTE;
-
-  } else if (checkStateWaitingEngageInstruction() == true) {
-    // STATE_WAITING_ENGAGE_INSTRUCTION
+  } else if (checkStateWaitingEngageInstruction()) {
     service_layer_state_ = autoware_state_machine_msgs::msg::StateMachine::STATE_WAITING_ENGAGE_INSTRUCTION;
-
-  } else if (checkStateWaitingCallPermission() == true) {
-    // STATE_WAITING_CALL_PERMISSION
+  } else if (checkStateWaitingCallPermission()) {
     service_layer_state_ = autoware_state_machine_msgs::msg::StateMachine::STATE_WAITING_CALL_PERMISSION;
-
-  } else if (checkState4Arrived() == true) {
-    // STATE_ARRIVED_GOAL
-    //setEngageProcess(false, false);    
+  } else if (checkState4Arrived()) {
     service_layer_state_ = autoware_state_machine_msgs::msg::StateMachine::STATE_ARRIVED_GOAL;
-
   } else {
-    // 上記以外
     service_layer_state_ = 0xFFFF;
   }
 
-  if ((operation_state_.is_stop_mode_available == true) ||
-      (operation_state_.is_local_mode_available == true)) {
+  if (operation_state_.is_autoware_control_enabled == false) {
     control_layer_state_ = autoware_state_machine_msgs::msg::StateMachine::MANUAL;
   } else {
     control_layer_state_ = autoware_state_machine_msgs::msg::StateMachine::AUTO;
   }
+
+  RCLCPP_INFO_THROTTLE(
+    this->get_logger(),
+    *this->get_clock(), 1.0,
+    "[WarningLampManager::changeState] service_layer_state: %s, control_layer_state: %s, "
+    "operation_mode: %u, motion_state: %u, is_autoware_control_enabled: %s, em_holding: %s",
+    getServiceLayerStateName(service_layer_state_),
+    control_layer_state_ == autoware_state_machine_msgs::msg::StateMachine::MANUAL ? "MANUAL" : "AUTO",
+    operation_state_.mode,
+    motion_state_,
+    operation_state_.is_autoware_control_enabled ? "true" : "false",
+    em_holding_ ? "true" : "false");
 }
 
 }  // namespace warning_lamp_manager

--- a/src/warning_lamp_manager.cpp
+++ b/src/warning_lamp_manager.cpp
@@ -40,10 +40,8 @@ const char * getServiceLayerStateName(uint16_t state)
       return "STATE_WAITING_CALL_PERMISSION";
     case autoware_state_machine_msgs::msg::StateMachine::STATE_ARRIVED_GOAL:
       return "STATE_ARRIVED_GOAL";
-    case autoware_state_machine_msgs::msg::StateMachine::STATE_DRIVING:
-      return "STATE_DRIVING";
     default:
-      return "UNKNOWN";
+      return "DEFAULT";
   }
 }
 }  // namespace


### PR DESCRIPTION
# description
The changes improve integration with updated Autoware message definitions and streamline the class's responsibilities.
and I made the changed colcon test

# Test
I checked

1.  colcon test passed 
2. warning_lamp and emergency_lamp status true/false of each states in Planning simulator.