### PR TITLE
refactor: update dependencies and message types in WarningLampManager

### DIFF
--- a/include/warning_lamp_manager/warning_lamp_manager.hpp
+++ b/include/warning_lamp_manager/warning_lamp_manager.hpp
@@ -18,7 +18,7 @@
 #include "rclcpp/rclcpp.hpp"
 #include "autoware_state_machine_msgs/msg/state_lock.hpp"
 #include "autoware_state_machine_msgs/msg/state_machine.hpp"
-#include "autoware_system_msgs/msg/hazard_status_stamped.hpp"
+#include "tier4_external_api_msgs/msg/hazard_status_stamped.hpp"
 #include "dio_ros_driver/msg/dio_port.hpp"
 #include "eve_cmd_gate_msgs/msg/engage_request_state.hpp"
 #include "go_interface_msgs/msg/vehicle_status.hpp"
@@ -50,7 +50,7 @@ private:
   rclcpp::Subscription<go_interface_msgs::msg::VehicleStatus>::SharedPtr sub_calls_vehicle_state_;
   rclcpp::Subscription<autoware_state_machine_msgs::msg::StateLock>::SharedPtr sub_delivery_reservation_state_;
   rclcpp::Subscription<eve_cmd_gate_msgs::msg::EngageRequestState>::SharedPtr sub_engage_process_state_;
-  rclcpp::Subscription<autoware_system_msgs::msg::HazardStatusStamped>::SharedPtr sub_hazard_status_;
+  rclcpp::Subscription<tier4_external_api_msgs::msg::HazardStatusStamped>::SharedPtr sub_hazard_status_;
   rclcpp::Subscription<autoware_adapi_v1_msgs::msg::MotionState>::SharedPtr sub_motion_state_;
 
   uint16_t motion_state_;
@@ -80,7 +80,7 @@ private:
   void callbackEngageProcessMessage(
     const eve_cmd_gate_msgs::msg::EngageRequestState::ConstSharedPtr msg);
   void callbackHazardStatusMessage(
-    const autoware_system_msgs::msg::HazardStatusStamped::ConstSharedPtr msg);
+    const tier4_external_api_msgs::msg::HazardStatusStamped::ConstSharedPtr msg);
   void callbackMotionStateMessage(
     const autoware_adapi_v1_msgs::msg::MotionState::ConstSharedPtr msg);
 

--- a/package.xml
+++ b/package.xml
@@ -35,7 +35,7 @@
   <depend>go_interface_msgs</depend>
   <depend>autoware_vehicle_msgs</depend>
   <depend>eve_cmd_gate_msgs</depend>
-  <depend>autoware_system_msgs</depend>
+  <depend>tier4_external_api_msgs</depend>
 
   <depend>builtin_interfaces</depend>
 

--- a/src/warning_lamp_manager.cpp
+++ b/src/warning_lamp_manager.cpp
@@ -53,8 +53,8 @@ WarningLampManager::WarningLampManager(const rclcpp::NodeOptions & options = rcl
     "/eve_cmd_gate/engage_request_state", rclcpp::QoS{3}.transient_local(),
     std::bind(&WarningLampManager::callbackEngageProcessMessage, this, std::placeholders::_1));
 
-  sub_hazard_status_ = this->create_subscription<autoware_system_msgs::msg::HazardStatusStamped>(
-    "/system/emergency/hazard_status", rclcpp::QoS{1},
+  sub_hazard_status_ = this->create_subscription<tier4_external_api_msgs::msg::HazardStatusStamped>(
+    "/api/external/get/hazard_status", rclcpp::QoS{1},
     std::bind(&WarningLampManager::callbackHazardStatusMessage, this, std::placeholders::_1));
 
   sub_motion_state_ = this->create_subscription<autoware_adapi_v1_msgs::msg::MotionState>(
@@ -145,7 +145,7 @@ void WarningLampManager::callbackEngageProcessMessage(
 }
 
 void WarningLampManager::callbackHazardStatusMessage(
-  const autoware_system_msgs::msg::HazardStatusStamped::ConstSharedPtr msg)
+  const tier4_external_api_msgs::msg::HazardStatusStamped::ConstSharedPtr msg)
 {
   em_holding_ = msg->status.emergency_holding;
 


### PR DESCRIPTION
# description
Migrate the `emergency_holding` topic from `/system/emergency/hazard_status` to `/api/external/get/hazard_status`.

# test
Psim launcher and rviz plugin set emergency 30seconds,/api/external/get/hazard_status's emergency_holding field is true.

ros2 topic echo /dio/dout1
and
when /api/external/get/hazard_status's emergency_holding field is true,
/dio/dout1 value changed false from true.